### PR TITLE
fix: replace legacy setuptools backend (Python 3.14 compat)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = ["setuptools>=68", "wheel"]
-build-backend = "setuptools.backends.legacy:build"
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "webxray"


### PR DESCRIPTION
## Problema
`setuptools.backends.legacy:build` fue eliminado en versiones recientes de setuptools y es incompatible con Python 3.14, causando:
```
BackendUnavailable: Cannot import 'setuptools.backends.legacy'
```

## Fix
Reemplazar por `setuptools.build_meta`, que es el backend estándar actual y compatible con Python 3.8+.